### PR TITLE
fix swweeep deep sleep

### DIFF
--- a/boards/shields/swweeep/swweeep.dtsi
+++ b/boards/shields/swweeep/swweeep.dtsi
@@ -28,6 +28,7 @@
 
     kscan0: kscan_0 {        
         compatible = "zmk,kscan-gpio-direct";
+        wakeup-source;
         input-gpios
             = <&pro_micro 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
             , <&pro_micro 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>


### PR DESCRIPTION
I noticed that my swweeep was not able to wake from deep sleep properly today, and it is because it was missing this one property.

See this announcement in the ZMK discord for context: https://discord.com/channels/719497620560543766/719544534500900886/1223354718005497988

> FYI: One small regression has been reported when enabling the ZMK_SLEEP config setting now that soft-off feature has been merged. I've fixed up all the [in-tree boards & shields](https://github.com/zmkfirmware/zmk/pull/2238) but if you are using a custom board/shield with deep sleep, you will need to fix the definition by adding a wakeup-source; property to all your kscan nodes. See https://zmk.dev/docs/development/new-shield#shield-overlays for an example of a kscan node with this property set correctly. Apologies for any disruption this may have caused you.